### PR TITLE
Downgrade setup.py to allow Django 2.2.x or greater

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name="django_chunk_upload_handlers",
-    version="0.0.7",
+    version="0.0.9",
     packages=setuptools.find_packages(),
     author="Ross Miller",
     author_email="ross.miller@digital.trade.gov.uk",
@@ -17,7 +17,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     install_requires=[
-        "django~=3.1.6",
+        "django>=2.2.22",
         "boto3~=1.14.10",
         "django-storages~=1.11.1",
     ],


### PR DESCRIPTION
This changeset downgrades the minimum Django requirement to 2.2.22 or greater

It also bumps the version number to 0.0.9, for a new release.

Tests still pass and a test-drive of the package locally, storing in S3 buckets, worked as expected.

