### PR TITLE
Use correct bucket name

### DIFF
--- a/django_chunk_upload_handlers/s3.py
+++ b/django_chunk_upload_handlers/s3.py
@@ -240,7 +240,7 @@ class S3FileUploadHandler(FileUploadHandler):
 
     def abort(self):
         self.s3_client.abort_multipart_upload(
-            Bucket=self.bucket_name,
+            Bucket=AWS_STORAGE_BUCKET_NAME,
             Key=self.s3_key,
             UploadId=self.upload_id,
         )


### PR DESCRIPTION
This ensures the `abort()` method doesn't fall over with an `AttributeError` since `self.bucket_name` is not valid.