### PR TITLE
fix: remove requirement for aws creds in env [ICMSLST-2501]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - run: pip install -r requirements.txt
       - run: tox -e "py${PYTHON_VERSION/./}"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version:
+          - "3.12"
+          - "3.11"
+          - "3.10"
+          - "3.9"
+          - "3.8"
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: tox -e "py${PYTHON_VERSION/./}"
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,13 @@ jobs:
       matrix:
         python-version:
           - "3.12"
-#          - "3.11"
-#          - "3.10"
-#          - "3.9"
-#          - "3.8"
+          - "3.11"
+          - "3.10"
+          - "3.9"
+          - "3.8"
 
     steps:
       - uses: actions/checkout@v4
-
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: ${{ matrix.python-version }}
 
       - run: pip install -r requirements.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,20 @@ jobs:
       matrix:
         python-version:
           - "3.12"
-          - "3.11"
-          - "3.10"
-          - "3.9"
-          - "3.8"
+#          - "3.11"
+#          - "3.10"
+#          - "3.9"
+#          - "3.8"
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+
+#      - uses: actions/setup-python@v5
+#        with:
+#          python-version: ${{ matrix.python-version }}
+
       - run: pip install -r requirements.txt
+
       - run: tox -e "py${PYTHON_VERSION/./}"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -53,12 +53,12 @@ S3
 :code:`AWS_ACCESS_KEY_ID`
 :code:`CHUNK_UPLOADER_AWS_ACCESS_KEY_ID`
 
-Provide either for the AWS access key required. ``CHUNK_UPLOADER_AWS_ACCESS_KEY_ID`` is preferred if both are set.
+Provide either for the AWS access key optional. ``CHUNK_UPLOADER_AWS_ACCESS_KEY_ID`` is preferred if both are set.
 
 :code:`AWS_SECRET_ACCESS_KEY`
 :code:`CHUNK_UPLOADER_AWS_SECRET_ACCESS_KEY`
 
-Provide either for the AWS access secret key required. ``CHUNK_UPLOADER_AWS_SECRET_ACCESS_KEY`` is preferred if both are set.
+Provide either for the AWS access secret key optional. ``CHUNK_UPLOADER_AWS_SECRET_ACCESS_KEY`` is preferred if both are set.
 
 :code:`AWS_STORAGE_BUCKET_NAME`
 :code:`CHUNK_UPLOADER_AWS_STORAGE_BUCKET_NAME`

--- a/django_chunk_upload_handlers/s3.py
+++ b/django_chunk_upload_handlers/s3.py
@@ -128,10 +128,12 @@ class S3FileUploadHandler(FileUploadHandler):
         if AWS_S3_ENDPOINT_URL:
             extra_kwargs['endpoint_url'] = AWS_S3_ENDPOINT_URL
 
+        if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+            extra_kwargs['aws_access_key_id'] = AWS_ACCESS_KEY_ID
+            extra_kwargs['aws_secret_access_key'] = AWS_SECRET_ACCESS_KEY
+
         self.s3_client = boto3_client(
             "s3",
-            aws_access_key_id=AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
             region_name=AWS_REGION,
             **extra_kwargs,
         )

--- a/django_chunk_upload_handlers/s3.py
+++ b/django_chunk_upload_handlers/s3.py
@@ -31,14 +31,8 @@ class AbortS3UploadException(UploadFileException):
 
 
 # AWS
-AWS_ACCESS_KEY_ID = check_required_setting(
-    "AWS_ACCESS_KEY_ID",
-    "CHUNK_UPLOADER_AWS_ACCESS_KEY_ID",
-)
-AWS_SECRET_ACCESS_KEY = check_required_setting(
-    "AWS_SECRET_ACCESS_KEY",
-    "CHUNK_UPLOADER_AWS_SECRET_ACCESS_KEY",
-)
+AWS_ACCESS_KEY_ID = getattr(settings, "AWS_ACCESS_KEY_ID", getattr(settings, 'CHUNK_UPLOADER_AWS_ACCESS_KEY_ID', None))
+AWS_SECRET_ACCESS_KEY = getattr(settings, "AWS_SECRET_ACCESS_KEY", getattr(settings, 'CHUNK_UPLOADER_AWS_SECRET_ACCESS_KEY', None))
 AWS_STORAGE_BUCKET_NAME = check_required_setting(
     "AWS_STORAGE_BUCKET_NAME",
     "CHUNK_UPLOADER_AWS_STORAGE_BUCKET_NAME",

--- a/django_chunk_upload_handlers/s3.py
+++ b/django_chunk_upload_handlers/s3.py
@@ -31,8 +31,12 @@ class AbortS3UploadException(UploadFileException):
 
 
 # AWS
-AWS_ACCESS_KEY_ID = getattr(settings, "AWS_ACCESS_KEY_ID", getattr(settings, 'CHUNK_UPLOADER_AWS_ACCESS_KEY_ID', None))
-AWS_SECRET_ACCESS_KEY = getattr(settings, "AWS_SECRET_ACCESS_KEY", getattr(settings, 'CHUNK_UPLOADER_AWS_SECRET_ACCESS_KEY', None))
+AWS_ACCESS_KEY_ID = getattr(settings,
+                            "CHUNK_UPLOADER_AWS_ACCESS_KEY_ID",
+                            getattr(settings, "AWS_ACCESS_KEY_ID", None))
+AWS_SECRET_ACCESS_KEY = getattr(settings,
+                                "CHUNK_UPLOADER_AWS_SECRET_ACCESS_KEY",
+                                getattr(settings, "AWS_SECRET_ACCESS_KEY", None))
 AWS_STORAGE_BUCKET_NAME = check_required_setting(
     "AWS_STORAGE_BUCKET_NAME",
     "CHUNK_UPLOADER_AWS_STORAGE_BUCKET_NAME",

--- a/django_chunk_upload_handlers/test/test_s3.py
+++ b/django_chunk_upload_handlers/test/test_s3.py
@@ -2,7 +2,6 @@ import concurrent.futures
 from datetime import datetime
 from unittest.mock import MagicMock, call, patch
 
-from django.conf import settings
 from django.test import TestCase
 from django.test.client import RequestFactory
 

--- a/django_chunk_upload_handlers/test/test_s3.py
+++ b/django_chunk_upload_handlers/test/test_s3.py
@@ -2,6 +2,7 @@ import concurrent.futures
 from datetime import datetime
 from unittest.mock import MagicMock, call, patch
 
+from django.conf import settings
 from django.test import TestCase
 from django.test.client import RequestFactory
 
@@ -32,10 +33,8 @@ class S3FileHandlerTestCase(TestCase):
 
     @patch("django_chunk_upload_handlers.s3.boto3_client")
     @patch("django_chunk_upload_handlers.s3.ThreadedS3ChunkUploader")
-    def test_init_connection(self, thread_pool, boto3_client):
-        self.s3_file_handler = S3FileUploadHandler(
-            request=self.request,
-        )
+    def test_init_connection_without_environment(self, thread_pool, boto3_client):
+        self.s3_file_handler = S3FileUploadHandler(request=self.request)
         self.s3_file_handler.new_file(
             "file",
             "file.txt",
@@ -45,6 +44,29 @@ class S3FileHandlerTestCase(TestCase):
         )
 
         self.s3_file_handler.s3_client.create_multipart_upload.assert_called_once()
+        boto3_client.assert_called_with("s3", region_name="")
+
+        thread_pool.assert_called_once()
+
+    @patch("django_chunk_upload_handlers.s3.boto3_client")
+    @patch("django_chunk_upload_handlers.s3.ThreadedS3ChunkUploader")
+    @patch("django_chunk_upload_handlers.s3.AWS_ACCESS_KEY_ID", 'access-key')
+    @patch("django_chunk_upload_handlers.s3.AWS_SECRET_ACCESS_KEY", 'secret-key')
+    def test_init_connection_with_environment(self, thread_pool, boto3_client):
+        self.s3_file_handler = S3FileUploadHandler(request=self.request)
+        self.s3_file_handler.new_file(
+            "file",
+            "file.txt",
+            "text/plain",
+            100,
+            content_type_extra=None,
+        )
+
+        self.s3_file_handler.s3_client.create_multipart_upload.assert_called_once()
+        boto3_client.assert_called_with("s3",
+                                        region_name="",
+                                        aws_access_key_id='access-key',
+                                        aws_secret_access_key='secret-key')
 
         thread_pool.assert_called_once()
 


### PR DESCRIPTION
- Make the following env vars optional:
  - `AWS_ACCESS_KEY_ID` and `CHUNK_UPLOADER_AWS_ACCESS_KEY_ID`
  - `AWS_SECRET_ACCESS_KEY` and `CHUNK_UPLOADER_AWS_SECRET_ACCESS_KEY `
- Add test for boto client with and without these settings.
- Add github actions test suite for all supported python versions